### PR TITLE
Allow independant nested projects

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.default]
+# Annoying, but tempfile doesn't seem to reliably create unique dirs?
+retries = 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1084,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -1527,10 +1539,14 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_fs"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d94b2a3f3786ff2996a98afbd6b4e5b7e890d685ccf67577f508ee2342c71cc9"
+dependencies = [
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +582,17 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -1554,6 +1579,7 @@ name = "unknown"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "assert_fs",
  "assert_matches",
  "async-trait",
  "atty",
@@ -1566,6 +1592,7 @@ dependencies = [
  "globset",
  "ignore",
  "insta",
+ "itertools",
  "knuffel",
  "maplit",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ colored = "2.0"
 futures = "0.3"
 globset = "0.4"
 ignore = "0.4.18"
+itertools = "0.10"
 knuffel = "2.0"
 miette = { version="4.7.1", features=["fancy"] }
 once_cell = "1.16.0"
@@ -31,8 +32,9 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 
 [dev-dependencies]
-assert_matches = "1.5.0"
 assert_cmd = "2.0"
+assert_fs = "1.0"
+assert_matches = "1.5.0"
 insta = "1.19"
 maplit = "1.0"
 rstest = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tabled = { version = "0.10.0", features=["derive"] }
 thiserror = "1.0"
 tokio = { version=  "1.21", features=["full"] }
 tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.16", features=["env-filter"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/cli/changed_command.rs
+++ b/src/cli/changed_command.rs
@@ -34,7 +34,7 @@ pub enum Format {
 }
 
 pub fn run(workspace: Workspace, opts: ChangedOpts) -> miette::Result<()> {
-    let files_changed = git::files_changed(git::Mode::Feature(opts.since))?;
+    let files_changed = git::files_changed(git::Mode::Feature(opts.since), None)?;
 
     let repo_root = git::repo_root().expect("need to find repo root");
     let repo_root = repo_root.as_path();

--- a/src/cli/changed_command.rs
+++ b/src/cli/changed_command.rs
@@ -1,8 +1,13 @@
 use std::collections::HashSet;
 
+use camino::Utf8Path;
 use tabled::{Table, Tabled};
 
-use crate::{config::ValidPath, git, workspace::Workspace};
+use crate::{
+    config::ValidPath,
+    git,
+    workspace::{ProjectInfo, Workspace},
+};
 
 #[derive(clap::Parser)]
 pub struct ChangedOpts {
@@ -34,13 +39,20 @@ pub fn run(workspace: Workspace, opts: ChangedOpts) -> miette::Result<()> {
     let repo_root = git::repo_root().expect("need to find repo root");
     let repo_root = repo_root.as_path();
 
+    if workspace.root_path() != repo_root {
+        return Err(miette::miette!("The workspace must be at the repo root currently (mostly because I'm lazy though, PRs welcome)"));
+    }
+
+    // Note: Possibly some room for optimisation here where we go project-by-project
+    // instead of file-by-file.  Could let us short-circuit things a bit, rather than
+    // needing to compare every file against every project
+
     let projects_changed = files_changed
         .into_iter()
-        .map(|p| repo_root.join(p))
         .flat_map(|file| {
             workspace
                 .projects()
-                .filter(|project| file.starts_with(project.root.full_path()))
+                .filter(|project| project.contains(&file))
                 .collect::<Vec<_>>()
         })
         .collect::<HashSet<_>>();
@@ -52,14 +64,17 @@ pub fn run(workspace: Workspace, opts: ChangedOpts) -> miette::Result<()> {
         .flat_map(|p| graph.walk_project_dependents(p.project_ref()))
         .collect::<HashSet<_>>();
 
-    // TODO: Probably topsort the output.
-    let outputs = projects_affected.into_iter().map(|project_ref| {
-        let project = project_ref.lookup(&workspace);
-        Output {
-            name: project.name.clone(),
-            path: project.root.clone(),
-        }
-    });
+    let mut outputs = projects_affected
+        .into_iter()
+        .map(|project_ref| {
+            let project = project_ref.lookup(&workspace);
+            Output {
+                name: project.name.clone(),
+                path: project.root.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+    outputs.sort_by(|lhs, rhs| lhs.path.cmp(&rhs.path));
 
     match opts.format.actual_format() {
         ActualFormat::Plain => {
@@ -71,7 +86,6 @@ pub fn run(workspace: Workspace, opts: ChangedOpts) -> miette::Result<()> {
             println!("{}", Table::new(outputs));
         }
         ActualFormat::Json => {
-            let outputs = outputs.collect::<Vec<_>>();
             print!("{}", serde_json::to_string(&outputs).unwrap())
         }
         ActualFormat::NdJson => {
@@ -136,5 +150,16 @@ impl std::str::FromStr for Format {
             "ndjson" => Format::NdJson,
             _ => miette::bail!("Unknown format: {s}.  Expected one of auto, plain, json, ndjson"),
         })
+    }
+}
+
+impl ProjectInfo {
+    fn contains(&self, path: &Utf8Path) -> bool {
+        path.starts_with(self.root.as_subpath())
+            && (self.path_exclusions.is_empty()
+                || !self
+                    .path_exclusions
+                    .iter()
+                    .any(|exclusion| path.starts_with(exclusion.as_subpath())))
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -36,7 +36,7 @@ pub enum Command {
 }
 
 pub fn run() -> miette::Result<()> {
-    tracing_subscriber::fmt::init();
+    setup_tracing();
 
     let opts = Cli::parse();
     let workspace = load_workspace()?;
@@ -64,6 +64,14 @@ fn load_workspace() -> Result<Workspace, miette::Report> {
     workspace.add_projects(config.project_files)?;
 
     Ok(workspace)
+}
+
+fn setup_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::filter::EnvFilter::from_env(
+            "UNKNOWN_LOG",
+        ))
+        .init();
 }
 
 #[cfg(test)]

--- a/src/cli/run_command/output.rs
+++ b/src/cli/run_command/output.rs
@@ -61,7 +61,7 @@ impl CommandOutput {
         color: Color,
     ) -> CommandOutput {
         let annotation = format!(
-            "{:>project_width$} | {:<task_width$} ",
+            "{:>project_width$} | {:<task_width$} | ",
             task.project_name,
             task.name,
             project_width = max_project_len,

--- a/src/config/paths.rs
+++ b/src/config/paths.rs
@@ -150,6 +150,12 @@ impl From<WorkspaceRoot> for ValidPath {
     }
 }
 
+impl PartialEq<Utf8Path> for WorkspaceRoot {
+    fn eq(&self, other: &Utf8Path) -> bool {
+        self.0 == other
+    }
+}
+
 impl WorkspaceRoot {
     pub fn new(path: impl Into<Utf8PathBuf>) -> Self {
         let mut path_buf = path.into();
@@ -322,6 +328,25 @@ impl ValidPath {
     // Normalises the provided path relative to self (or the root of the repo if path is absolute)
     fn join_and_validate(&self, path: impl Into<Utf8PathBuf>) -> Result<ValidPath, PathError> {
         self.join(path)?.validate()
+    }
+
+    /// Determines whether `base` is a prefix of `self`.
+    ///
+    /// Only considers whole path components to match.
+    pub fn starts_with(&self, base: &ValidPath) -> bool {
+        self.workspace_root == base.workspace_root && self.subpath.starts_with(&base.subpath)
+    }
+
+    #[cfg(test)]
+    /// A test only constructor function for creating invalid ValidPaths.
+    pub fn new_for_tests(
+        workspace_root: &WorkspaceRoot,
+        subpath: impl Into<Utf8PathBuf>,
+    ) -> ValidPath {
+        ValidPath {
+            workspace_root: workspace_root.clone(),
+            subpath: subpath.into(),
+        }
     }
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,4 @@
-use std::path::PathBuf;
-
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use thiserror::Error;
 
 pub type Commit = String;
@@ -23,17 +21,17 @@ pub enum GitError {
     Unknown(String),
 }
 
-pub fn repo_root() -> Result<PathBuf, GitError> {
-    real_impl().repo_root().map(PathBuf::from)
+pub fn repo_root() -> Result<Utf8PathBuf, GitError> {
+    real_impl().repo_root().map(Utf8PathBuf::from)
 }
 
-pub fn files_changed(mode: Mode) -> Result<Vec<PathBuf>, GitError> {
+pub fn files_changed(mode: Mode) -> Result<Vec<Utf8PathBuf>, GitError> {
     let paths = real_impl().diff(mode, vec![])?;
 
-    Ok(paths.into_iter().map(PathBuf::from).collect())
+    Ok(paths.into_iter().map(Utf8PathBuf::from).collect())
 }
 
-pub fn have_files_changed(since: String, path: camino::Utf8PathBuf) -> Result<bool, GitError> {
+pub fn have_files_changed(since: String, path: Utf8PathBuf) -> Result<bool, GitError> {
     let paths = real_impl().diff(Mode::Main(since), vec![path.to_string()])?;
 
     Ok(!paths.is_empty())
@@ -133,6 +131,7 @@ where
                 files
                     .trim_end()
                     .split('\n')
+                    .filter(|f| !f.is_empty())
                     .map(|f| f.to_string())
                     .collect()
             })

--- a/src/git.rs
+++ b/src/git.rs
@@ -25,16 +25,10 @@ pub fn repo_root() -> Result<Utf8PathBuf, GitError> {
     real_impl().repo_root().map(Utf8PathBuf::from)
 }
 
-pub fn files_changed(mode: Mode) -> Result<Vec<Utf8PathBuf>, GitError> {
-    let paths = real_impl().diff(mode, vec![])?;
+pub fn files_changed(mode: Mode, path: Option<Utf8PathBuf>) -> Result<Vec<Utf8PathBuf>, GitError> {
+    let paths = real_impl().diff(mode, path.into_iter().map(|p| p.into()).collect())?;
 
     Ok(paths.into_iter().map(Utf8PathBuf::from).collect())
-}
-
-pub fn have_files_changed(since: String, path: Utf8PathBuf) -> Result<bool, GitError> {
-    let paths = real_impl().diff(Mode::Main(since), vec![path.to_string()])?;
-
-    Ok(!paths.is_empty())
 }
 
 pub fn sparse_checkout_init() -> Result<(), GitError> {

--- a/src/hashing/tests.rs
+++ b/src/hashing/tests.rs
@@ -16,10 +16,10 @@ mod hash_file_inputs {
         let mut first_hashes = Vec::new();
         let mut second_hashes = Vec::new();
 
-        let globs = &[Glob::new("*").unwrap()];
+        let globs = globset(&["*"]);
 
-        hash_file_inputs(&files.root().into(), globs, &mut first_hashes).unwrap();
-        hash_file_inputs(&files.root().into(), globs, &mut second_hashes).unwrap();
+        hash_file_inputs(&files.root().into(), globs.clone(), &[], &mut first_hashes).unwrap();
+        hash_file_inputs(&files.root().into(), globs, &[], &mut second_hashes).unwrap();
 
         assert_eq!(first_hashes, second_hashes)
     }
@@ -33,13 +33,13 @@ mod hash_file_inputs {
         let mut first_hashes = Vec::new();
         let mut second_hashes = Vec::new();
 
-        let globs = &[Glob::new("*").unwrap()];
+        let globs = globset(&["*"]);
 
-        hash_file_inputs(&files.root().into(), globs, &mut first_hashes).unwrap();
+        hash_file_inputs(&files.root().into(), globs.clone(), &[], &mut first_hashes).unwrap();
 
         files.add_file("test.txt", "");
 
-        hash_file_inputs(&files.root().into(), globs, &mut second_hashes).unwrap();
+        hash_file_inputs(&files.root().into(), globs, &[], &mut second_hashes).unwrap();
 
         assert_ne!(first_hashes, second_hashes)
     }
@@ -51,15 +51,51 @@ mod hash_file_inputs {
         let mut first_hashes = Vec::new();
         let mut second_hashes = Vec::new();
 
-        let globs = &[Glob::new("src/*").unwrap()];
+        let globs = globset(&["src/*"]);
 
-        hash_file_inputs(&files.root().into(), globs, &mut first_hashes).unwrap();
+        hash_file_inputs(&files.root().into(), globs.clone(), &[], &mut first_hashes).unwrap();
 
         // Add a file that does not match our glob
         files.add_file("test.txt", "");
 
-        hash_file_inputs(&files.root().into(), globs, &mut second_hashes).unwrap();
+        hash_file_inputs(&files.root().into(), globs, &[], &mut second_hashes).unwrap();
 
         assert_eq!(first_hashes, second_hashes)
+    }
+
+    #[test]
+    fn test_excludes_arent_hashed() {
+        let mut files = TestFiles::new()
+            .with_file("src/hello", r#"project "hello""#)
+            .with_file("src/nested/blah", "");
+
+        let mut first_hashes = Vec::new();
+        let mut second_hashes = Vec::new();
+
+        let globs = globset(&["src/*"]);
+        let excludes = [ValidPath::new_for_tests(&files.root(), "src/nested")];
+
+        hash_file_inputs(
+            &files.root().into(),
+            globs.clone(),
+            &excludes,
+            &mut first_hashes,
+        )
+        .unwrap();
+
+        // Add a file that does not match our glob
+        files.add_file("src/nested/test.txt", "");
+
+        hash_file_inputs(&files.root().into(), globs, &excludes, &mut second_hashes).unwrap();
+
+        assert_eq!(first_hashes, second_hashes)
+    }
+
+    fn globset(paths: &[&str]) -> Option<GlobSet> {
+        let mut builder = GlobSetBuilder::new();
+        for path in paths {
+            builder.add(Glob::new(path).unwrap());
+        }
+        Some(builder.build().unwrap())
     }
 }

--- a/src/workspace/exclusions.rs
+++ b/src/workspace/exclusions.rs
@@ -1,0 +1,95 @@
+use std::collections::BTreeMap;
+
+use crate::config::ValidPath;
+
+use super::ProjectRef;
+
+/// Each project might also contain other projects.  This function calculates
+/// which paths to exclude from each project based on the set of paths for each project.
+pub fn calculate_exclusions<'a>(
+    input: impl Iterator<Item = (ProjectRef, &'a ValidPath)>,
+) -> BTreeMap<ProjectRef, Vec<ValidPath>> {
+    let mut project_paths = input.collect::<Vec<_>>();
+
+    // sort_by_key doesn't let you return references, so here's the ugly full form :(
+    project_paths.sort_by(|(_, p1), (_, p2)| p1.cmp(p2));
+
+    let mut exclusions = BTreeMap::new();
+    let mut projects = project_paths.iter();
+    while let Some((project, path)) = projects.next() {
+        let subpaths = projects
+            .clone()
+            .take_while(|(_, other_path)| other_path.starts_with(path))
+            .map(|(_, path)| *path)
+            .collect::<Vec<_>>();
+
+        // Next, filter out any nested subpaths so we end up with the smallest exclusion
+        // list possible.
+        let mut filtered_paths = Vec::with_capacity(subpaths.len());
+        let mut subpaths = subpaths.into_iter().rev().peekable();
+        while let Some(path) = subpaths.next() {
+            if let Some(next) = subpaths.peek() {
+                if path.starts_with(next) {
+                    continue;
+                }
+            }
+            filtered_paths.push(path.clone());
+        }
+        filtered_paths.reverse();
+
+        // Ideally want to simplify these exclusions as well...
+
+        exclusions.insert(project.clone(), filtered_paths);
+    }
+
+    exclusions
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{
+        config::{ValidPath, WorkspaceRoot},
+        workspace::ProjectRef,
+    };
+
+    use super::calculate_exclusions;
+
+    #[test]
+    fn test_calculate_exclusions() {
+        let input = [
+            test_pair("libs/one"),
+            test_pair("libs/two"),
+            test_pair("libs/one/subproject"),
+            test_pair("libs/one/subproject/nested"),
+            test_pair("libs/one-but-not-a-folder"),
+        ];
+
+        let exclusions = calculate_exclusions(input.iter().map(|(p, r)| (p.clone(), r)))
+            .into_iter()
+            .map(|(project, paths)| {
+                let paths = paths
+                    .into_iter()
+                    .map(|p| p.as_subpath().to_owned())
+                    .collect::<Vec<_>>();
+
+                (project.as_str().to_owned(), paths)
+            })
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(exclusions["libs/one"], vec!["libs/one/subproject"]);
+        assert!(exclusions["libs/two"].is_empty());
+        assert_eq!(
+            exclusions["libs/one/subproject"],
+            vec!["libs/one/subproject/nested"]
+        );
+        assert!(exclusions["libs/one/subproject/nested"].is_empty());
+        assert!(exclusions["libs/one-but-not-a-folder"].is_empty());
+    }
+
+    fn test_pair(path: &str) -> (ProjectRef, ValidPath) {
+        let path = ValidPath::new_for_tests(&WorkspaceRoot::new("/Users/naebody/src"), path);
+        (ProjectRef(path.clone()), path)
+    }
+}

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -18,7 +18,7 @@ mod graph;
 mod tests;
 
 use camino::Utf8Path;
-use globset::Glob;
+use globset::{Glob, GlobSet};
 
 pub struct Workspace {
     pub info: WorkspaceInfo,
@@ -242,7 +242,7 @@ impl TaskRef {
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ProjectInfo {
     pub name: String,
-    pub dependencies: Vec<ProjectRef>,
+    dependencies: Vec<ProjectRef>,
     pub root: ValidPath,
     pub path_exclusions: Vec<ValidPath>,
 }
@@ -508,5 +508,18 @@ impl TaskInputs {
             self.commands.push(_command.to_owned());
             todo!("Haven't implemented command input support yet");
         }
+    }
+
+    pub fn globset(&self) -> Option<GlobSet> {
+        if self.paths.is_empty() {
+            return None;
+        }
+
+        let mut builder = globset::GlobSetBuilder::new();
+        for glob in &self.paths {
+            builder.add(glob.clone());
+        }
+
+        Some(builder.build().expect("the globset build to succeed"))
     }
 }

--- a/src/workspace/snapshots/unknown__workspace__tests__snapshot_sample_monorepo.snap
+++ b/src/workspace/snapshots/unknown__workspace__tests__snapshot_sample_monorepo.snap
@@ -42,6 +42,7 @@ Workspace {
                 ),
                 subpath: "projects/a-lib",
             },
+            path_exclusions: [],
         },
         ProjectRef(
             ValidPath {
@@ -68,6 +69,7 @@ Workspace {
                 ),
                 subpath: "projects/a-service",
             },
+            path_exclusions: [],
         },
     },
     task_map: {

--- a/tests/changed_command.rs
+++ b/tests/changed_command.rs
@@ -8,8 +8,9 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 fn test_changed_command() -> Result<()> {
     let mut temp_dir = TempDir::new()?;
 
-    temp_dir = temp_dir.into_persistent();
-    println!("Not So Temp Dir: {temp_dir:?}");
+    // Note: Uncomment these if you're debugging
+    // temp_dir = temp_dir.into_persistent();
+    // println!("Not So Temp Dir: {temp_dir:?}");
 
     temp_dir
         .child("workspace.kdl")

--- a/tests/changed_command.rs
+++ b/tests/changed_command.rs
@@ -1,0 +1,90 @@
+use assert_cmd::Command;
+use assert_fs::{prelude::*, TempDir};
+use similar_asserts::assert_eq;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[test]
+fn test_changed_command() -> Result<()> {
+    let mut temp_dir = TempDir::new()?;
+
+    temp_dir = temp_dir.into_persistent();
+    println!("Not So Temp Dir: {temp_dir:?}");
+
+    temp_dir
+        .child("workspace.kdl")
+        .write_str("name \"test_changed_command\"\n")?;
+    temp_dir.child("service/project.kdl").write_str(
+        r#"
+      project "service"
+      dependencies {
+        project "/library"
+      }
+    "#,
+    )?;
+    temp_dir.child("service/file.txt").touch()?;
+    temp_dir
+        .child("service/nested/project.kdl")
+        .write_str(r#"project "nested-service""#)?;
+    temp_dir
+        .child("library/project.kdl")
+        .write_str(r#"project "library""#)?;
+
+    let library_file = temp_dir.child("library/file.txt");
+    let service_file = temp_dir.child("service/file.txt");
+    let nested_service_file = temp_dir.child("service/nested/file.txt");
+
+    library_file.touch()?;
+    service_file.touch()?;
+    nested_service_file.touch()?;
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(&temp_dir)
+        .ok()?;
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(&temp_dir)
+        .ok()?;
+    Command::new("git")
+        .args(["commit", "-m", "whatevs"])
+        .current_dir(&temp_dir)
+        .ok()?;
+
+    assert_eq!(run_changed(&mut temp_dir)?, Vec::<String>::new());
+
+    nested_service_file.write_str("update")?;
+    assert_eq!(run_changed(&mut temp_dir)?, vec!["service/nested"]);
+
+    service_file.write_str("update")?;
+    assert_eq!(
+        run_changed(&mut temp_dir)?,
+        vec!["service", "service/nested"]
+    );
+
+    service_file.write_str("")?;
+    nested_service_file.write_str("")?;
+    assert_eq!(run_changed(&mut temp_dir)?, Vec::<String>::new());
+
+    library_file.write_str("update")?;
+    assert_eq!(run_changed(&mut temp_dir)?, vec!["library", "service"]);
+
+    Ok(())
+}
+
+fn run_changed(dir: &mut TempDir) -> Result<Vec<String>> {
+    #[derive(serde::Deserialize)]
+    struct Output {
+        path: String,
+    }
+
+    let output = serde_json::from_slice::<Vec<Output>>(
+        &Command::cargo_bin("unknown")?
+            .args(["changed", "--format", "json"])
+            .current_dir(dir)
+            .ok()?
+            .stdout,
+    )?;
+
+    Ok(output.into_iter().map(|o| o.path).collect())
+}

--- a/tests/run_command.rs
+++ b/tests/run_command.rs
@@ -1,0 +1,283 @@
+use std::ffi;
+
+use assert_cmd::Command;
+use assert_fs::{fixture::ChildPath, prelude::*, TempDir};
+use similar_asserts::assert_eq;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[test]
+fn no_changes_git() -> Result<()> {
+    let workspace = setup_workspace()?;
+
+    insta::assert_snapshot!(
+        "no_changes_git.stdout",
+        workspace.run(["run", "build", "--since", "HEAD"])
+    );
+
+    Ok(())
+}
+
+#[test]
+fn building_service() {
+    let workspace = setup_workspace().unwrap();
+
+    // Now make sure we're doing nothing when we re-run
+    insta::assert_snapshot!(
+        "building_service.stdout",
+        workspace.run(["run", "build", "--filter", "service"])
+    );
+}
+
+#[test]
+fn doesnt_rerun_nested_if_inputs_unchanged() {
+    let workspace = setup_workspace().unwrap();
+
+    // Setup our hashes
+    workspace.run(["run", "build"]);
+
+    // Now make sure nested doesn't get rebuilt
+    insta::assert_snapshot!(
+        "doesnt_rerun_nested_if_inputs_unchanged.stdout",
+        workspace.run(["run", "build"])
+    );
+}
+
+#[test]
+fn pulls_in_dependencies() {
+    let workspace = setup_workspace().unwrap();
+    insta::assert_snapshot!(
+        "pulls_in_dependencies.stdout",
+        workspace.run(["run", "build", "--filter", "service"])
+    );
+}
+
+#[test]
+fn failures_stop_execution() {
+    let workspace = setup_workspace().unwrap();
+    let (stdout, stderr) = workspace.run_failure(["run", "fail", "--filter", "service"]);
+    insta::assert_snapshot!("failures_stop_execution.stdout", stdout);
+    insta::assert_snapshot!("failures_stop_execution.stderr", stderr);
+}
+
+#[test]
+fn nested_file_change_with_since() {
+    let workspace = setup_workspace().unwrap();
+
+    workspace.nested_service_file.write_str("hello").unwrap();
+
+    // This should build _just_ the nested service, despite the fact that the
+    // changed file is also nested under service
+    insta::assert_snapshot!(
+        "nested_file_change_with_since.stdout",
+        workspace.run(["run", "build", "--since", "HEAD"])
+    );
+}
+
+#[test]
+fn change_to_a_non_input_file_is_ignored_with_since() {
+    let workspace = setup_workspace().unwrap();
+
+    workspace
+        .non_input_nested_service_file
+        .write_str("hello")
+        .unwrap();
+
+    assert_eq!(workspace.run(["run", "build", "--since", "HEAD"]), "");
+}
+
+#[test]
+fn nested_file_change_with_hashes() {
+    let workspace = setup_workspace().unwrap();
+
+    // setup the hashes.
+    workspace.run(["run", "build"]);
+
+    workspace.nested_service_file.write_str("hello").unwrap();
+
+    // TOOD: don't approve the snapshot on this till it works.
+
+    // This should build _just_ the nested service, despite the fact that the
+    // changed file is also nested under service
+    insta::assert_snapshot!(
+        "nested_file_change_with_hashes.stdout",
+        workspace.run(["run", "build", "--filter", "nested,service"])
+    );
+}
+
+#[test]
+fn change_to_a_non_input_file_is_ignored_with_hashes() {
+    let workspace = setup_workspace().unwrap();
+
+    // setup the hashes.
+    workspace.run(["run", "build"]);
+
+    workspace
+        .non_input_nested_service_file
+        .write_str("hello")
+        .unwrap();
+
+    assert_eq!(workspace.run(["run", "build", "--filter", "nested"]), "");
+}
+
+#[test]
+fn filter_implicitly_set_to_current_folders_project() {
+    let workspace = setup_workspace().unwrap();
+
+    let output = Command::cargo_bin("unknown")
+        .unwrap()
+        .args(["run", "build"])
+        .current_dir(&workspace.root.child("library"))
+        .ok()
+        .unwrap();
+
+    assert_eq!(String::from_utf8(output.stderr).unwrap(), "");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    insta::assert_snapshot!(
+        "filter_implicitly_set_to_current_folders_project.stdout",
+        stdout
+    );
+}
+
+#[allow(dead_code)]
+struct TestWorkspace {
+    root: TempDir,
+    library_file: ChildPath,
+    service_file: ChildPath,
+    nested_service_file: ChildPath,
+    non_input_nested_service_file: ChildPath,
+}
+
+impl TestWorkspace {
+    fn run<I, S>(&self, args: I) -> String
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<ffi::OsStr>,
+    {
+        let output = Command::cargo_bin("unknown")
+            .unwrap()
+            .args(args)
+            .current_dir(&self.root)
+            .ok()
+            .unwrap();
+
+        assert_eq!(String::from_utf8(output.stderr).unwrap(), "");
+        String::from_utf8(output.stdout).unwrap()
+    }
+
+    fn run_failure<I, S>(&self, args: I) -> (String, String)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<ffi::OsStr>,
+    {
+        let output = Command::cargo_bin("unknown")
+            .unwrap()
+            .args(args)
+            .current_dir(&self.root)
+            .output()
+            .unwrap();
+
+        (
+            String::from_utf8(output.stdout).unwrap(),
+            String::from_utf8(output.stderr).unwrap(),
+        )
+    }
+}
+
+fn setup_workspace() -> Result<TestWorkspace> {
+    let mut temp_dir = TempDir::new()?;
+
+    // Note: Uncomment these if you're debugging
+    temp_dir = temp_dir.into_persistent();
+    println!("Not So Temp Dir: {temp_dir:?}");
+
+    temp_dir
+        .child("workspace.kdl")
+        .write_str("name \"test_changed_command\"\n")?;
+    temp_dir.child("service/project.kdl").write_str(
+        r##"
+            project "service"
+            dependencies {
+                project "/library"
+            }
+
+            tasks {
+                task "build" {
+                    requires "build" in="^self"
+                    command r#"echo "Building Service""#
+                    inputs {
+                        path "**"
+                    }
+                }
+                task "fail" {
+                    requires "fail" in="library"
+                    command r#"echo "If you see this, the test has failed""#
+                }
+            }
+        "##,
+    )?;
+    temp_dir.child("service/nested/project.kdl").write_str(
+        r##"
+            project "nested"
+
+            tasks {
+                task "build" {
+                    command r#"echo "Building Nested""#
+                    inputs {
+                        // TODO: Ok, something up with this file specification
+                        path "file.txt"
+                    }
+                }
+            }
+        "##,
+    )?;
+    temp_dir.child("library/project.kdl").write_str(
+        r##"
+            project "library"
+
+            tasks {
+                task "build" {
+                    command r#"echo "Building Library""#
+                    inputs {
+                        path "**"
+                    }
+                }
+                task "fail" {
+                    // Just some nonsense command that'll output an error code.
+                    command "git fail"
+                }
+            }
+        "##,
+    )?;
+
+    let library_file = temp_dir.child("library/file.txt");
+    let service_file = temp_dir.child("service/file.txt");
+    let nested_service_file = temp_dir.child("service/nested/file.txt");
+    let non_input_nested_service_file = temp_dir.child("service/nested/other.txt");
+
+    library_file.touch()?;
+    service_file.touch()?;
+    nested_service_file.touch()?;
+    non_input_nested_service_file.touch()?;
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(&temp_dir)
+        .ok()?;
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(&temp_dir)
+        .ok()?;
+    Command::new("git")
+        .args(["commit", "-m", "whatevs"])
+        .current_dir(&temp_dir)
+        .ok()?;
+
+    Ok(TestWorkspace {
+        root: temp_dir,
+        library_file,
+        service_file,
+        nested_service_file,
+        non_input_nested_service_file,
+    })
+}

--- a/tests/snapshots/run_command__building_service.stdout.snap
+++ b/tests/snapshots/run_command__building_service.stdout.snap
@@ -1,0 +1,7 @@
+---
+source: tests/run_command.rs
+expression: "workspace.run([\"run\", \"build\", \"--filter\", \"service\"])"
+---
+library | build | "Building Library"
+service | build | "Building Service"
+

--- a/tests/snapshots/run_command__doesnt_rerun_nested_if_inputs_unchanged.stdout.snap
+++ b/tests/snapshots/run_command__doesnt_rerun_nested_if_inputs_unchanged.stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tests/run_command.rs
+expression: "workspace.run([\"run\", \"build\"])"
+---
+

--- a/tests/snapshots/run_command__failures_stop_execution.stderr.snap
+++ b/tests/snapshots/run_command__failures_stop_execution.stderr.snap
@@ -1,0 +1,6 @@
+---
+source: tests/run_command.rs
+expression: stderr
+---
+library | fail | git: 'fail' is not a git command. See 'git --help'.
+

--- a/tests/snapshots/run_command__failures_stop_execution.stdout.snap
+++ b/tests/snapshots/run_command__failures_stop_execution.stdout.snap
@@ -1,0 +1,6 @@
+---
+source: tests/run_command.rs
+expression: stdout
+---
+library::fail failed :(
+

--- a/tests/snapshots/run_command__filter_implicitly_set_to_current_folders_project.stdout.snap
+++ b/tests/snapshots/run_command__filter_implicitly_set_to_current_folders_project.stdout.snap
@@ -1,0 +1,6 @@
+---
+source: tests/run_command.rs
+expression: stdout
+---
+library | build | "Building Library"
+

--- a/tests/snapshots/run_command__nested_file_change_with_hashes.stdout.snap
+++ b/tests/snapshots/run_command__nested_file_change_with_hashes.stdout.snap
@@ -1,0 +1,6 @@
+---
+source: tests/run_command.rs
+expression: "workspace.run([\"run\", \"build\", \"--filter\", \"nested,service\"])"
+---
+ nested | build | "Building Nested"
+

--- a/tests/snapshots/run_command__nested_file_change_with_since.stdout.snap
+++ b/tests/snapshots/run_command__nested_file_change_with_since.stdout.snap
@@ -1,0 +1,6 @@
+---
+source: tests/run_command.rs
+expression: "workspace.run([\"run\", \"build\", \"--since\", \"HEAD\"])"
+---
+ nested | build | "Building Nested"
+

--- a/tests/snapshots/run_command__no_changes_git.stdout.snap
+++ b/tests/snapshots/run_command__no_changes_git.stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tests/run_command.rs
+expression: stdout
+---
+

--- a/tests/snapshots/run_command__no_hash_changes.stdout.snap
+++ b/tests/snapshots/run_command__no_hash_changes.stdout.snap
@@ -1,0 +1,8 @@
+---
+source: tests/run_command.rs
+expression: "workspace.run([\"run\", \"build\"])"
+---
+       library | build | "Building Library"
+nested-service | build | "Building Nested"
+       service | build | "Building Service"
+

--- a/tests/snapshots/run_command__pulls_in_dependencies.stdout.snap
+++ b/tests/snapshots/run_command__pulls_in_dependencies.stdout.snap
@@ -1,0 +1,7 @@
+---
+source: tests/run_command.rs
+expression: "workspace.run([\"run\", \"build\", \"--filter\", \"service\"])"
+---
+library | build | "Building Library"
+service | build | "Building Service"
+


### PR DESCRIPTION
I want unknown to be able to support "subprojects" - projects that are nested inside the directory of another project.  It sort of did this already, but any changes to files inside a nested project would also be considered a change of the parent projects files.

This updates projects to contain a set of "excluded paths" and updates the changed command to take these paths into account.

Will also need to update the run command to do the same, which I'll do in a future commit.